### PR TITLE
fix master build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+loglevel=http

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,11 @@ language: node_js
 
 node_js:
   - "0.10"
+  - "2"
+  - "4"
+  - "6"
+  - "8"
+  - "10"
+  - "12"
 
 after_success: make coveralls

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "deep-extend": "^0.2.8"
   },
   "devDependencies": {
-    "mocha": "~1.17.1",
-    "should": "~3.1.3",
+    "mocha": "^3",
+    "should": "^13",
     "coveralls": "~2.8.0",
-    "istanbul": "~0.2.6"
+    "istanbul": "^0.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
hi there. i'm sitting on a couple of feature commits (two different CLI versions, and symbolic-mode), but in preparing the pull requests i noticed that master no longer builds on `node@0.10` because some of mocha's dependencies have shifted and now require syntax only available in newer versions of node (`>=6` to be precise). i thought it might be a good idea to add a build matrix to cover newer versions of node, and found versions of `devDependencies` that work for the entire matrix for now.

here was the failure in master that i encountered:
https://travis-ci.org/abacaphiliac/chmod/builds/564708119

* builds `chmod` on several different versions of node
* `mocha@1` depended on `debug@*` which uses newer node syntax, so `mocha` had to be upgraded to a magical version that pinned to a "goldilocks" version of `debug` (i think it's `debug@2`)
* ignored `package-lock.json` so that it is not accidentally committed, and is still present for running `npm audit`
* upgraded other `devDependencies` while i was in the neighborhood